### PR TITLE
Configure Strapi integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for Strapi
+STRAPI_API_URL=http://localhost:1337
+STRAPI_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to view the website.
 
+## Strapi Configuration
+
+Create an `.env.local` file in the project root with the following variables:
+
+```bash
+STRAPI_API_URL=http://localhost:1337
+STRAPI_API_TOKEN=<your-private-token>
+```
+
+The token should be kept server-side for security. Avoid using the
+`NEXT_PUBLIC_` prefix so it is not exposed to the browser.
+
 ## File Structure
 
 All of the code for this template is located in the `/src` folder. The folder contains the following:

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,21 @@
 /** @type {import('next').NextConfig} */
 
+const strapiUrl =
+  process.env.STRAPI_API_URL ||
+  process.env.NEXT_PUBLIC_STRAPI_API_URL ||
+  'http://localhost:1337';
+
+const { protocol, hostname, port } = new URL(strapiUrl);
+
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    // This allows you to use images from your Strapi instance
+    // Allow images from the configured Strapi instance
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '1337',
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port: port || '',
         pathname: '/uploads/**',
       },
     ],
@@ -16,6 +23,6 @@ const nextConfig = {
       360, 414, 512, 640, 750, 828, 1080, 1200, 1536, 1920, 2048, 3840,
     ],
   },
-}
+};
 
 module.exports = nextConfig

--- a/src/lib/strapi.js
+++ b/src/lib/strapi.js
@@ -1,13 +1,19 @@
 import qs from 'qs';
 
-const STRAPI_API_URL = process.env.STRAPI_API_URL || 'http://localhost:1337';
-// Read the variable with the correct NEXT_PUBLIC_ prefix
-const STRAPI_API_TOKEN = process.env.NEXT_PUBLIC_STRAPI_API_TOKEN;
+const STRAPI_API_URL =
+  process.env.STRAPI_API_URL ||
+  process.env.NEXT_PUBLIC_STRAPI_API_URL ||
+  'http://localhost:1337';
+// Prefer the private token but support the old public variable for backwards compatibility
+const STRAPI_API_TOKEN =
+  process.env.STRAPI_API_TOKEN || process.env.NEXT_PUBLIC_STRAPI_API_TOKEN;
 
 export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
   // Check if the token is missing and provide a clear error
   if (!STRAPI_API_TOKEN) {
-    throw new Error('The Strapi API token is missing. Please check your .env.local file and ensure the variable is named NEXT_PUBLIC_STRAPI_API_TOKEN');
+    throw new Error(
+      'The Strapi API token is missing. Please define STRAPI_API_TOKEN in your environment.'
+    );
   }
 
   const mergedOptions = {


### PR DESCRIPTION
## Summary
- secure the Strapi API token usage
- allow configuring the Strapi URL for images via env vars
- document how to configure Strapi
- provide example `.env` file

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found)*

------
https://chatgpt.com/codex/tasks/task_e_688650721b148326a64179f4ec9bd2d9