### PR TITLE
Add REVALIDATE_INTERVAL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for Strapi
 STRAPI_API_URL=http://localhost:1337
 STRAPI_API_TOKEN=
+REVALIDATE_INTERVAL= # Next.js fetch revalidation in seconds (defaults to 60)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Create an `.env.local` file in the project root with the following variables:
 ```bash
 STRAPI_API_URL=http://localhost:1337
 STRAPI_API_TOKEN=<your-private-token>
+REVALIDATE_INTERVAL=60 # optional revalidation time in seconds
 ```
 
 The token should be kept server-side for security. Avoid using the
@@ -41,6 +42,9 @@ The token should be kept server-side for security. Avoid using the
 Make sure your Strapi instance is running and reachable at the
 `STRAPI_API_URL`. If the API is unavailable or the token is invalid the site
 will fail to fetch content and you may see `500` errors in development.
+
+`REVALIDATE_INTERVAL` controls how often Next.js will revalidate data
+fetched from Strapi. The default is `60` seconds.
 
 ## File Structure
 

--- a/src/lib/strapi.js
+++ b/src/lib/strapi.js
@@ -5,6 +5,8 @@ const STRAPI_API_URL =
   'http://localhost:1337';
 const STRAPI_API_TOKEN =
   process.env.STRAPI_API_TOKEN;
+const REVALIDATE_INTERVAL =
+  Number(process.env.REVALIDATE_INTERVAL || 60);
 
 export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
   // Check if the token is missing and provide a clear error
@@ -19,6 +21,7 @@ export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${STRAPI_API_TOKEN}`,
     },
+    next: { revalidate: REVALIDATE_INTERVAL },
     ...options,
   }
 


### PR DESCRIPTION
## Summary
- revalidate Strapi requests using an interval from env
- document the revalidation setting in the example env file and README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886ecaec914832699a1a32a42bb13fe