### PR TITLE
Allow dynamic routes to pre-build slugs

### DIFF
--- a/src/app/blog/(index)/categories/[categorySlug]/page.jsx
+++ b/src/app/blog/(index)/categories/[categorySlug]/page.jsx
@@ -48,4 +48,4 @@ export default async function BlogCategoryPage({ params }) {
   return <BlogGrid posts={posts} />
 }
 
-export const dynamicParams = false
+export const dynamicParams = true

--- a/src/app/blog/[slug]/page.jsx
+++ b/src/app/blog/[slug]/page.jsx
@@ -132,4 +132,4 @@ export default async function BlogPost({ params }) {
   )
 }
 
-export const dynamicParams = false
+export const dynamicParams = true

--- a/src/app/work/(index)/categories/[tagSlug]/page.jsx
+++ b/src/app/work/(index)/categories/[tagSlug]/page.jsx
@@ -41,4 +41,4 @@ export default async function WorkCategoryPage({ params }) {
   return <CaseStudies caseStudies={caseStudies} />
 }
 
-export const dynamicParams = false
+export const dynamicParams = true

--- a/src/app/work/[slug]/page.jsx
+++ b/src/app/work/[slug]/page.jsx
@@ -65,4 +65,4 @@ export default async function CaseStudyPage({ params }) {
   )
 }
 
-export const dynamicParams = false
+export const dynamicParams = true


### PR DESCRIPTION
## Summary
- enable dynamic params for blog & work dynamic routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886ecb023448326b8b68cb7555b9b44