### PR TITLE
Update Next.js to use homepage endpoint

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -12,11 +12,18 @@ export const metadata = {
 }
 
 async function getHomepageData() {
+  const homepageRes = await fetchAPI('/homepage', { populate: '*' })
+
+  if (homepageRes?.data) {
+    return homepageRes.data.attributes
+  }
+
+  // Fallback for older Strapi setups
   const [testimonialsRes, caseStudiesRes, postsRes] = await Promise.all([
     fetchAPI('/testimonials', { populate: '*' }),
     fetchAPI('/case-studies', { sort: { date: 'desc' }, pagination: { limit: 4 }, populate: '*' }),
     fetchAPI('/posts', { sort: { date: 'desc' }, pagination: { limit: 3 }, populate: '*' }),
-  ]);
+  ])
 
   return {
     testimonials: testimonialsRes.data || [],
@@ -26,7 +33,8 @@ async function getHomepageData() {
 }
 
 export default async function HomePage() {
-  const { testimonials, caseStudies, posts } = await getHomepageData();
+  const homepage = (await getHomepageData()) || {};
+  const { testimonials = [], caseStudies = [], posts = [] } = homepage;
   const global = await getGlobal();
 
   return (
@@ -40,3 +48,4 @@ export default async function HomePage() {
     </>
   )
 }
+

--- a/src/lib/strapi.js
+++ b/src/lib/strapi.js
@@ -55,7 +55,12 @@ export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
 }
 
 export async function getGlobal() {
-  let globalRes = await fetchAPI('/global', { populate: '*' })
+  // Prefer the dedicated homepage endpoint when available
+  let globalRes = await fetchAPI('/homepage', { populate: '*' })
+
+  if (!globalRes.data) {
+    globalRes = await fetchAPI('/global', { populate: '*' })
+  }
 
   if (!globalRes.data) {
     globalRes = await fetchAPI('/globals', { populate: '*' })


### PR DESCRIPTION
## Summary
- retrieve global data from `/homepage` with fallbacks
- fetch homepage data from `/homepage` with a fallback to existing endpoints
- guard against missing homepage data before destructuring

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68870faa7ddc8326b1ca14bca987c254