### PR TITLE
Improve Strapi token handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example environment variables for Strapi
 STRAPI_API_URL=http://localhost:1337
+# Generate a token in Strapi and place it here
 STRAPI_API_TOKEN=
 REVALIDATE_INTERVAL=60 # Next.js fetch revalidation in seconds
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ REVALIDATE_INTERVAL=60 # revalidate Strapi fetches every 60 seconds
 
 The token should be kept server-side for security. Avoid using the
 `NEXT_PUBLIC_` prefix so it is not exposed to the browser.
+If `STRAPI_API_TOKEN` is omitted, the site will attempt public requests only and
+log a warning, but private content will not load.
 
 Make sure your Strapi instance is running and reachable at the
 `STRAPI_API_URL`. If the API is unavailable or the token is invalid the site

--- a/src/lib/strapi.js
+++ b/src/lib/strapi.js
@@ -9,17 +9,19 @@ const REVALIDATE_INTERVAL = parseInt(
 );
 
 export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
-  if (!STRAPI_API_TOKEN) {
-    throw new Error(
-      'The Strapi API token is missing. Please define STRAPI_API_TOKEN in your environment.'
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (STRAPI_API_TOKEN) {
+    headers.Authorization = `Bearer ${STRAPI_API_TOKEN}`;
+  } else {
+    console.warn(
+      'The Strapi API token is missing. Define STRAPI_API_TOKEN to access private content.'
     );
   }
 
   const mergedOptions = {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${STRAPI_API_TOKEN}`,
-    },
+    headers,
     next: { revalidate: REVALIDATE_INTERVAL },
     ...options,
   };


### PR DESCRIPTION
## Summary
- avoid throwing errors when the Strapi token is missing
- document that STRAPI_API_TOKEN is needed for private content
- clarify token usage in `.env.example`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887442ded688326bcb212fd0759ecdc