### PR TITLE
Update work layout and navigation

### DIFF
--- a/src/app/work/(index)/layout.jsx
+++ b/src/app/work/(index)/layout.jsx
@@ -33,12 +33,6 @@ export default async function WorkLayout({ children }) {
                 transformative learning experiences—from bespoke curriculum
                 design to hands-on teacher training and community engagement.
               </p>
-              <Link
-                href='/work'
-                className='mt-6 inline-block rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-emerald-700'
-              >
-                Browse All Case Studies
-              </Link>
             </div>
             <Tabs
               className='mt-14 gap-x-1.5 gap-y-4 md:gap-x-1 lg:mt-16 lg:gap-2'

--- a/src/components/work/CaseStudyNavigation.js
+++ b/src/components/work/CaseStudyNavigation.js
@@ -37,8 +37,8 @@ export async function CaseStudyNavigation({ caseStudySlug }) {
   return (
     <section className="py-8 border-t border-slate-200">
       <Container>
-        <div className="flex items-center justify-between">
-          <Link href={prevCaseStudyUrl} className="group space-y-1.5">
+        <div className="grid grid-cols-3 items-center justify-items-center">
+          <Link href={prevCaseStudyUrl} className="group space-y-1.5 justify-self-start">
             <div className="flex items-center gap-1 duration-200 text-slate-500 group-hover:text-sky-500">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -64,7 +64,7 @@ export async function CaseStudyNavigation({ caseStudySlug }) {
 
           <Link
             href="/work"
-            className="flex items-center justify-center w-12 h-12 duration-200 rounded-full shadow-sm group bg-slate-50 ring-1 ring-slate-100/80 hover:bg-sky-600 md:h-14 md:w-14"
+            className="mx-auto flex items-center justify-center w-12 h-12 duration-200 rounded-full shadow-sm group bg-slate-50 ring-1 ring-slate-100/80 hover:bg-sky-600 md:h-14 md:w-14"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -80,7 +80,7 @@ export async function CaseStudyNavigation({ caseStudySlug }) {
             </svg>
           </Link>
 
-          <Link href={nextCaseStudyUrl} className="group space-y-1.5">
+          <Link href={nextCaseStudyUrl} className="group space-y-1.5 justify-self-end text-right">
             <div className="flex items-center justify-end gap-1 duration-200 text-slate-500 group-hover:text-sky-500">
               Next
               <svg


### PR DESCRIPTION
## Summary
- remove "Browse All Case Studies" link from the work page header
- center the "Browse all projects" navigation button more accurately

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888113d8b748326a6b2e0ce60a9489b