### PR TITLE
feat: require API token outside development

### DIFF
--- a/apps/web/src/lib/strapi.js
+++ b/apps/web/src/lib/strapi.js
@@ -14,6 +14,10 @@ export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
   };
   if (STRAPI_API_TOKEN) {
     headers.Authorization = `Bearer ${STRAPI_API_TOKEN}`;
+  } else if (process.env.NODE_ENV !== 'development') {
+    throw new Error(
+      'STRAPI_API_TOKEN must be defined when NODE_ENV is not development.'
+    );
   } else {
     console.warn(
       'The Strapi API token is missing. Define STRAPI_API_TOKEN to access private content.'


### PR DESCRIPTION
## Summary
- throw an error when STRAPI_API_TOKEN is missing outside development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive prompt in `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d0d84db083269885d09c437b6120