### PR TITLE
Handle Strapi logo dimensions and enforce HTTPS images

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,10 +1,11 @@
 /** @type {import('next').NextConfig} */
 
 const strapiUrl =
+  process.env.NEXT_PUBLIC_STRAPI_API_URL ||
   process.env.STRAPI_API_URL ||
-  'http://localhost:1337';
+  'https://localhost:1337';
 
-const { protocol, hostname, port } = new URL(strapiUrl);
+const { hostname } = new URL(strapiUrl);
 
 const nextConfig = {
   reactStrictMode: true,
@@ -12,9 +13,8 @@ const nextConfig = {
     // Allow images from the configured Strapi instance
     remotePatterns: [
       {
-        protocol: protocol.replace(':', ''),
+        protocol: 'https',
         hostname,
-        port: port || '',
         pathname: '/uploads/**',
       },
     ],

--- a/apps/web/src/components/Header.js
+++ b/apps/web/src/components/Header.js
@@ -31,6 +31,8 @@ const links = [
 export function Header() {
   const pathname = usePathname()
   const [logoUrl, setLogoUrl] = useState(null)
+  const [logoWidth, setLogoWidth] = useState(null)
+  const [logoHeight, setLogoHeight] = useState(null)
   const [bookCallUrl, setBookCallUrl] = useState('#')
 
   useEffect(() => {
@@ -52,6 +54,12 @@ export function Header() {
         const mediaUrl = getStrapiMedia(data?.logo)
         if (mediaUrl) {
           setLogoUrl(mediaUrl)
+          const width = Number(data?.logo?.data?.attributes?.width)
+          const height = Number(data?.logo?.data?.attributes?.height)
+          if (Number.isFinite(width) && Number.isFinite(height)) {
+            setLogoWidth(width)
+            setLogoHeight(height)
+          }
         }
         const callUrl = data?.bookCallUrl
         try {
@@ -131,12 +139,18 @@ export function Header() {
                 alt=''
                 className='h-8 w-auto sm:h-9 md:hidden lg:block lg:h-16'
                 priority
+                {...(logoUrl && logoWidth && logoHeight
+                  ? { width: logoWidth, height: logoHeight }
+                  : {})}
               />
               <Image
                 src={logoUrl || logoIcon}
                 alt=''
                 className='hidden h-8 w-auto md:block lg:hidden'
                 priority
+                {...(logoUrl && logoWidth && logoHeight
+                  ? { width: logoWidth, height: logoHeight }
+                  : {})}
               />
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- store logo width/height from Strapi site settings and apply to Image components
- allow remote Strapi images over HTTPS only in Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b419eb894c8326993e4fecd5ca8a24