### PR TITLE
Use secure Strapi logo with explicit dimensions

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,10 +1,8 @@
 /** @type {import('next').NextConfig} */
 
-const strapiUrl =
-  process.env.STRAPI_API_URL ||
-  'http://localhost:1337';
-
-const { protocol, hostname, port } = new URL(strapiUrl);
+const strapiUrl = process.env.STRAPI_API_URL || 'http://localhost:1337';
+const { hostname, port } = new URL(strapiUrl);
+const isLocalhost = ['localhost', '127.0.0.1'].includes(hostname);
 
 const nextConfig = {
   reactStrictMode: true,
@@ -12,9 +10,9 @@ const nextConfig = {
     // Allow images from the configured Strapi instance
     remotePatterns: [
       {
-        protocol: protocol.replace(':', ''),
+        protocol: isLocalhost ? 'http' : 'https',
         hostname,
-        port: port || '',
+        port: isLocalhost ? port : '',
         pathname: '/uploads/**',
       },
     ],

--- a/apps/web/src/components/Header.js
+++ b/apps/web/src/components/Header.js
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import clsx from 'clsx'
 import {
   Popover,
@@ -17,6 +18,7 @@ import { Button } from './Button'
 import { Container } from './Container'
 import logo from '@/images/logo-image.png'
 import logoIcon from '@/images/logo-icon.png'
+import { getStrapiMedia } from '@/lib/strapi'
 
 const links = [
   { label: 'Home', href: '/' },
@@ -28,6 +30,54 @@ const links = [
 
 export function Header() {
   const pathname = usePathname()
+  const [logoUrl, setLogoUrl] = useState(null)
+  const [logoWidth, setLogoWidth] = useState(null)
+  const [logoHeight, setLogoHeight] = useState(null)
+  const [bookCallUrl, setBookCallUrl] = useState('#')
+
+  useEffect(() => {
+    const controller = new AbortController()
+    async function loadSettings() {
+      try {
+        const baseUrl =
+          process.env.NEXT_PUBLIC_STRAPI_API_URL ||
+          process.env.STRAPI_API_URL ||
+          'http://localhost:1337'
+        const url = new URL('/api/site-setting', baseUrl)
+        url.searchParams.set('populate', 'logo')
+        const res = await fetch(url.toString(), { signal: controller.signal })
+        if (!res.ok) {
+          throw new Error('Failed to fetch site settings')
+        }
+        const json = await res.json()
+        const data = json.data?.attributes || json.data
+        const media = data?.logo?.data?.attributes
+        const mediaUrl = getStrapiMedia(data?.logo)
+        if (
+          mediaUrl &&
+          Number.isFinite(media?.width) &&
+          Number.isFinite(media?.height)
+        ) {
+          setLogoUrl(mediaUrl)
+          setLogoWidth(media.width)
+          setLogoHeight(media.height)
+        }
+        const callUrl = data?.bookCallUrl
+        try {
+          const parsed = new URL(callUrl)
+          if (parsed.protocol === 'https:') {
+            setBookCallUrl(parsed.toString())
+          }
+        } catch {
+          /* ignore invalid URLs */
+        }
+      } catch (err) {
+        console.error('Error loading site settings', err)
+      }
+    }
+    loadSettings()
+    return () => controller.abort()
+  }, [])
 
   function Hamburger() {
     return (
@@ -86,14 +136,20 @@ export function Header() {
               className='flex flex-shrink-0 items-center'
             >
               <Image
-                src={logo}
+                src={logoUrl || logo}
+                width={logoUrl ? logoWidth || logo.width : logo.width}
+                height={logoUrl ? logoHeight || logo.height : logo.height}
                 alt=''
                 className='h-8 w-auto sm:h-9 md:hidden lg:block lg:h-16'
+                priority
               />
               <Image
-                src={logoIcon}
+                src={logoUrl || logoIcon}
+                width={logoUrl ? logoWidth || logoIcon.width : logoIcon.width}
+                height={logoUrl ? logoHeight || logoIcon.height : logoIcon.height}
                 alt=''
                 className='hidden h-8 w-auto md:block lg:hidden'
+                priority
               />
             </Link>
           </div>
@@ -114,7 +170,7 @@ export function Header() {
             ))}
           </div>
           <div className='flex items-center'>
-            <Button variant='primary' href='#'>
+            <Button variant='primary' href={bookCallUrl}>
               Book a call
             </Button>
             <div className='ml-4 md:hidden'>

--- a/apps/web/src/lib/strapi.js
+++ b/apps/web/src/lib/strapi.js
@@ -100,7 +100,10 @@ export function getStrapiMedia(media) {
   if (!url) return null
   try {
     const absoluteUrl = new URL(url, STRAPI_API_URL)
-    if (absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:') {
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(
+      absoluteUrl.hostname,
+    )
+    if (absoluteUrl.protocol === 'https:' || isLocalhost) {
       return absoluteUrl.toString()
     }
   } catch {}


### PR DESCRIPTION
## Summary
- load logo dimensions from Strapi site settings and pass them to `next/image`
- restrict remote image loading to HTTPS Strapi hosts (except localhost)
- only accept HTTPS or localhost media URLs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b40b2013988326964635c7ec5a26a3