### PR TITLE
feat: add secure site settings and homepage

### DIFF
--- a/apps/cms/config/middlewares.ts
+++ b/apps/cms/config/middlewares.ts
@@ -1,12 +1,23 @@
-export default [
-  'strapi::logger',
-  'strapi::errors',
-  'strapi::security',
-  'strapi::cors',
-  'strapi::poweredBy',
-  'strapi::query',
-  'strapi::body',
-  'strapi::session',
-  'strapi::favicon',
-  'strapi::public',
-];
+export default ({ env }) => {
+  const origin = env('CORS_ORIGIN', 'https://localhost:3000')
+  if (!origin.startsWith('https://')) {
+    throw new Error('CORS_ORIGIN must use https')
+  }
+  return [
+    'strapi::logger',
+    'strapi::errors',
+    'strapi::security',
+    {
+      name: 'strapi::cors',
+      config: {
+        origin: origin.split(','),
+      },
+    },
+    'strapi::poweredBy',
+    'strapi::query',
+    'strapi::body',
+    'strapi::session',
+    'strapi::favicon',
+    'strapi::public',
+  ]
+}

--- a/apps/cms/config/plugins.ts
+++ b/apps/cms/config/plugins.ts
@@ -1,1 +1,13 @@
-export default () => ({});
+export default ({ env }) => ({
+  upload: {
+    config: {
+      sizeLimit: env.int('UPLOAD_MAX_SIZE', 5 * 1024 * 1024),
+      mimeTypes: [
+        'image/png',
+        'image/jpeg',
+        'image/svg+xml',
+        'video/mp4',
+      ],
+    },
+  },
+});

--- a/apps/cms/config/server.ts
+++ b/apps/cms/config/server.ts
@@ -1,6 +1,7 @@
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
+  url: env('STRAPI_URL', 'https://localhost:1337'),
   app: {
     keys: env.array('APP_KEYS'),
   },

--- a/apps/cms/src/api/homepage/content-types/homepage/schema.json
+++ b/apps/cms/src/api/homepage/content-types/homepage/schema.json
@@ -15,18 +15,22 @@
     }
   },
   "attributes": {
-    "logo": {
-      "type": "media",
+    "heroText": {
+      "type": "text",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "multiple": false,
-      "allowedTypes": [
-        "images",
-        "files"
-      ]
+      }
+    },
+    "heroMedia": {
+      "type": "media",
+      "allowedTypes": ["images", "videos"],
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/apps/cms/src/api/site-settings/content-types/site-settings/schema.json
+++ b/apps/cms/src/api/site-settings/content-types/site-settings/schema.json
@@ -1,0 +1,28 @@
+{
+  "kind": "singleType",
+  "collectionName": "site_settings",
+  "info": {
+    "singularName": "site-settings",
+    "pluralName": "site-settings",
+    "displayName": "Site Settings"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "logo": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    },
+    "bookCallUrl": {
+      "type": "string",
+      "regex": "^https://"
+    },
+    "socialLinks": {
+      "type": "component",
+      "repeatable": true,
+      "component": "shared.social-link"
+    }
+  }
+}

--- a/apps/cms/src/api/site-settings/controllers/site-settings.ts
+++ b/apps/cms/src/api/site-settings/controllers/site-settings.ts
@@ -1,0 +1,7 @@
+/**
+ * site-settings controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::site-settings.site-settings');

--- a/apps/cms/src/api/site-settings/routes/site-settings.ts
+++ b/apps/cms/src/api/site-settings/routes/site-settings.ts
@@ -1,0 +1,7 @@
+/**
+ * site-settings router
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreRouter('api::site-settings.site-settings');

--- a/apps/cms/src/api/site-settings/services/site-settings.ts
+++ b/apps/cms/src/api/site-settings/services/site-settings.ts
@@ -1,0 +1,7 @@
+/**
+ * site-settings service
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreService('api::site-settings.site-settings');

--- a/apps/cms/src/components/shared/social-link.json
+++ b/apps/cms/src/components/shared/social-link.json
@@ -5,23 +5,24 @@
   },
   "options": {},
   "attributes": {
-    "label": {
+    "platform": {
       "type": "string",
       "required": true
     },
-    "href": {
+    "url": {
       "type": "string",
       "required": true,
-      "regex": "/^https?:\\\\/\\\\//"
+      "regex": "^https://"
     },
-    "platform": {
+    "icon": {
       "type": "enumeration",
       "enum": [
         "Facebook",
         "Instagram",
         "LinkedIn",
         "Email"
-      ]
+      ],
+      "required": true
     }
   },
   "config": {}

--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -1,4 +1,4 @@
-// import type { Core } from '@strapi/strapi';
+import type { Core } from '@strapi/strapi';
 
 export default {
   /**
@@ -16,5 +16,22 @@ export default {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/* { strapi }: { strapi: Core.Strapi } */) {},
+  async bootstrap({ strapi }: { strapi: Core.Strapi }) {
+    const roleService = strapi.plugins['users-permissions'].services.role
+    const roles = await roleService.find()
+    const publicRole = roles.find((role: any) => role.type === 'public')
+    if (publicRole) {
+      await roleService.updateRole(publicRole.id, {
+        permissions: {
+          ...publicRole.permissions,
+          'api::homepage.homepage': {
+            find: true,
+          },
+          'api::site-settings.site-settings': {
+            find: true,
+          },
+        },
+      })
+    }
+  },
 };

--- a/apps/cms/types/generated/components.d.ts
+++ b/apps/cms/types/generated/components.d.ts
@@ -65,11 +65,13 @@ export interface SharedSocialLink extends Struct.ComponentSchema {
     displayName: 'socialLink';
   };
   attributes: {
-    href: Schema.Attribute.String & Schema.Attribute.Required;
-    label: Schema.Attribute.String & Schema.Attribute.Required;
-    platform: Schema.Attribute.Enumeration<
+    platform: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetRegex<'^https://'>;
+    icon: Schema.Attribute.Enumeration<
       ['Facebook', 'Instagram', 'LinkedIn', 'Email']
-    >;
+    > & Schema.Attribute.Required;
   };
 }
 

--- a/apps/cms/types/generated/contentTypes.d.ts
+++ b/apps/cms/types/generated/contentTypes.d.ts
@@ -481,18 +481,49 @@ export interface ApiHomepageHomepage extends Struct.SingleTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    locale: Schema.Attribute.String;
-    localizations: Schema.Attribute.Relation<
-      'oneToMany',
-      'api::homepage.homepage'
-    >;
-    logo: Schema.Attribute.Media<'images' | 'files'> &
+    heroMedia: Schema.Attribute.Media<'images' | 'videos'> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
         };
       }>;
+    heroText: Schema.Attribute.Text &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::homepage.homepage'
+    >;
     publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiSiteSettingsSiteSettings extends Struct.SingleTypeSchema {
+  collectionName: 'site_settings';
+  info: {
+    displayName: 'Site Settings';
+    pluralName: 'site-settings';
+    singularName: 'site-settings';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    bookCallUrl: Schema.Attribute.String &
+      Schema.Attribute.SetRegex<'^https://'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    logo: Schema.Attribute.Media<'images'>;
+    publishedAt: Schema.Attribute.DateTime;
+    socialLinks: Schema.Attribute.Component<'shared.social-link', true>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1182,6 +1213,7 @@ declare module '@strapi/strapi' {
       'admin::user': AdminUser;
       'api::case-study.case-study': ApiCaseStudyCaseStudy;
       'api::homepage.homepage': ApiHomepageHomepage;
+      'api::site-settings.site-settings': ApiSiteSettingsSiteSettings;
       'api::page.page': ApiPagePage;
       'api::post.post': ApiPostPost;
       'api::tag.tag': ApiTagTag;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,10 +3,13 @@
 const strapiUrl =
   process.env.STRAPI_API_URL ||
   process.env.NEXT_PUBLIC_STRAPI_API_URL ||
-  'http://localhost:1337';
+  'https://localhost:1337';
 
-const { hostname, port } = new URL(strapiUrl);
+const { hostname, port, protocol } = new URL(strapiUrl);
 const isLocalhost = ['localhost', '127.0.0.1'].includes(hostname);
+if (!isLocalhost && protocol !== 'https:') {
+  throw new Error('STRAPI_API_URL must use https');
+}
 
 // Optional separate uploads host, e.g. a CDN
 const uploadsUrl =

--- a/apps/web/src/app/layout.jsx
+++ b/apps/web/src/app/layout.jsx
@@ -1,4 +1,6 @@
 import { Header } from '@/components/Header'
+import { Footer } from '@/components/Footer'
+import { getSiteSettings } from '@/lib/strapi'
 import clsx from 'clsx'
 import { Inter, Lexend, Gochi_Hand } from 'next/font/google'
 import '@/styles/globals.css'
@@ -28,7 +30,8 @@ export const metadata = {
   },
 }
 
-export default function RootLayout({ children }) {
+export default async function RootLayout({ children }) {
+  const siteSettings = await getSiteSettings()
   return (
     <html lang="en">
       <body
@@ -39,8 +42,12 @@ export default function RootLayout({ children }) {
           gochiHand.variable
         )}
       >
-        <Header />
+        <Header siteSettings={siteSettings} />
         {children}
+        <Footer
+          socialLinks={siteSettings.socialLinks}
+          bookCallUrl={siteSettings.bookCallUrl}
+        />
       </body>
     </html>
   )

--- a/apps/web/src/app/page.jsx
+++ b/apps/web/src/app/page.jsx
@@ -3,7 +3,6 @@ import { Experience } from '@/components/Experience'
 import { FeaturedWork } from '@/components/work/FeaturedWork'
 import { Testimonials } from '@/components/Testimonials'
 import { FeaturedPosts } from '@/components/blog/FeaturedPosts'
-import { Footer } from '@/components/Footer'
 import { fetchAPI } from '@/lib/strapi'
 
 export const metadata = {
@@ -65,7 +64,6 @@ export default async function HomePage() {
       <FeaturedWork caseStudies={caseStudies} />
       <Testimonials testimonials={testimonials} />
       <FeaturedPosts posts={posts} />
-      <Footer {...(homepage.footer || {})} />
     </>
   )
 }

--- a/apps/web/src/components/Footer.js
+++ b/apps/web/src/components/Footer.js
@@ -20,21 +20,28 @@ const defaultLinks = [
   { label: 'Contact', href: '/contact' },
 ]
 
+const iconMap = {
+  Facebook: FacebookIcon,
+  Instagram: InstagramIcon,
+  LinkedIn: LinkedInIcon,
+  Email: EmailIcon,
+}
+
 const defaultSocialLinks = [
   {
-    label: 'Facebook',
-    icon: FacebookIcon,
-    href: "#"
+    platform: 'Facebook',
+    icon: 'Facebook',
+    url: '#'
   },
   {
-    label: 'Instagram',
-    icon: InstagramIcon,
-    href: '#',
+    platform: 'Instagram',
+    icon: 'Instagram',
+    url: '#',
   },
   {
-    label: 'LinkedIn',
-    icon: LinkedInIcon,
-    href: '#',
+    platform: 'LinkedIn',
+    icon: 'LinkedIn',
+    url: '#',
   },
 ]
 
@@ -54,6 +61,7 @@ export function Footer({
   newsletter = true,
   links = defaultLinks,
   socialLinks = defaultSocialLinks,
+  bookCallUrl = '#',
   newsletterHeading = 'Subscribe to my educator insights',
   newsletterSubtext =
     'Join a community of forward‑thinking school leaders and receive exclusive tips on teacher training, starting and growing schools, and building student‑centred institutions delivered straight to your inbox.',
@@ -112,7 +120,7 @@ export function Footer({
                 Let’s transform education together
               </h3>
               <div className="hidden lg:block">
-                <Button href="#" variant="primary" className="mt-12">
+                <Button href={bookCallUrl} variant="primary" className="mt-12">
                   Book a call
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -135,7 +143,7 @@ export function Footer({
               </p>
 
               <Button
-                href="#"
+                href={bookCallUrl}
                 variant="primary"
                 className="mt-10 lg:hidden"
               >
@@ -154,14 +162,17 @@ export function Footer({
                 </svg>
               </Button>
               <div className="mt-16 grid w-full max-w-sm grid-cols-2 gap-3.5 sm:max-w-none sm:grid-cols-3 lg:mt-8 lg:gap-2.5 xl:gap-3.5">
-                {socialLinks.map((socialLink) => (
-                  <SocialLink
-                    key={`footer-social-link-${socialLink.label}`}
-                    icon={socialLink.icon}
-                    label={socialLink.label}
-                    href={socialLink.href}
-                  />
-                ))}
+                {socialLinks.map((socialLink) => {
+                  const Icon = iconMap[socialLink.icon] || iconMap[socialLink.platform]
+                  return (
+                    <SocialLink
+                      key={`footer-social-link-${socialLink.platform}`}
+                      icon={Icon}
+                      label={socialLink.platform}
+                      href={socialLink.url}
+                    />
+                  )
+                })}
               </div>
             </div>
           </div>

--- a/apps/web/src/components/Header.js
+++ b/apps/web/src/components/Header.js
@@ -3,7 +3,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
-import { useEffect, useState } from 'react'
 import clsx from 'clsx'
 import {
   Popover,
@@ -28,56 +27,20 @@ const links = [
   { label: 'Contact', href: '/contact' },
 ]
 
-export function Header() {
+export function Header({ siteSettings = {} }) {
   const pathname = usePathname()
-  const [logoUrl, setLogoUrl] = useState(null)
-  const [logoWidth, setLogoWidth] = useState(null)
-  const [logoHeight, setLogoHeight] = useState(null)
-  const [bookCallUrl, setBookCallUrl] = useState('#')
-
-  useEffect(() => {
-    const controller = new AbortController()
-    async function loadSettings() {
-      try {
-        const baseUrl =
-          process.env.NEXT_PUBLIC_STRAPI_API_URL ||
-          process.env.STRAPI_API_URL ||
-          'http://localhost:1337'
-        const url = new URL('/api/site-setting', baseUrl)
-        url.searchParams.set('populate', 'logo')
-        const res = await fetch(url.toString(), { signal: controller.signal })
-        if (!res.ok) {
-          throw new Error('Failed to fetch site settings')
-        }
-        const json = await res.json()
-        const data = json.data?.attributes || json.data
-        const media = data?.logo?.data?.attributes
-        const mediaUrl = getStrapiMedia(data?.logo)
-        if (
-          mediaUrl &&
-          Number.isFinite(media?.width) &&
-          Number.isFinite(media?.height)
-        ) {
-          setLogoUrl(mediaUrl)
-          setLogoWidth(media.width)
-          setLogoHeight(media.height)
-        }
-        const callUrl = data?.bookCallUrl
-        try {
-          const parsed = new URL(callUrl)
-          if (parsed.protocol === 'https:') {
-            setBookCallUrl(parsed.toString())
-          }
-        } catch {
-          /* ignore invalid URLs */
-        }
-      } catch (err) {
-        console.error('Error loading site settings', err)
-      }
+  const media = getStrapiMedia(siteSettings.logo)
+  const mediaAttrs = siteSettings.logo?.data?.attributes || {}
+  const logoUrl = media
+  const logoWidth = mediaAttrs.width
+  const logoHeight = mediaAttrs.height
+  let bookCallUrl = '#'
+  try {
+    const parsed = new URL(siteSettings.bookCallUrl)
+    if (parsed.protocol === 'https:') {
+      bookCallUrl = parsed.toString()
     }
-    loadSettings()
-    return () => controller.abort()
-  }, [])
+  } catch {}
 
   function Hamburger() {
     return (

--- a/apps/web/src/lib/strapi.js
+++ b/apps/web/src/lib/strapi.js
@@ -2,6 +2,12 @@ import qs from 'qs';
 
 const STRAPI_API_URL =
   process.env.STRAPI_API_URL || 'http://localhost:1337';
+const IS_LOCALHOST =
+  STRAPI_API_URL.startsWith('http://localhost') ||
+  STRAPI_API_URL.startsWith('http://127.0.0.1');
+if (!IS_LOCALHOST && !STRAPI_API_URL.startsWith('https://')) {
+  throw new Error('STRAPI_API_URL must use https');
+}
 const STRAPI_API_TOKEN = process.env.STRAPI_API_TOKEN;
 const REVALIDATE_INTERVAL = parseInt(
   process.env.REVALIDATE_INTERVAL ?? '60',
@@ -59,6 +65,18 @@ export async function fetchAPI(path, urlParamsObject = {}, options = {}) {
 
   const data = await response.json();
   return data;
+}
+
+export async function getSiteSettings() {
+  const settingsRes = await fetchAPI('/site-settings', {
+    populate: {
+      logo: '*',
+      socialLinks: { populate: '*' },
+    },
+  });
+  const record = settingsRes.data;
+  const attrs = record?.attributes ?? record;
+  return attrs || {};
 }
 
 // Updated to return data whether it's under `attributes` (v4) or directly on the record (v5).


### PR DESCRIPTION
## Summary
- add global site settings single type with logo, URL and links
- secure uploads, CORS and role permissions
- integrate site settings into Next.js layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint --workspaces` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b42708b3b08326a780004fab014b28