### PR TITLE
chore: add typed site settings factories

### DIFF
--- a/apps/cms/src/api/site-settings/controllers/site-settings.ts
+++ b/apps/cms/src/api/site-settings/controllers/site-settings.ts
@@ -2,6 +2,12 @@
  * site-settings controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
+import type { UID } from '@strapi/strapi';
 
-export default factories.createCoreController('api::site-settings.site-settings');
+export default factories.createCoreController<
+  'api::site-settings.site-settings',
+  {}
+>(
+  'api::site-settings.site-settings' satisfies UID.ContentType
+);

--- a/apps/cms/src/api/site-settings/routes/site-settings.ts
+++ b/apps/cms/src/api/site-settings/routes/site-settings.ts
@@ -2,6 +2,9 @@
  * site-settings router
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
+import type { UID } from '@strapi/strapi';
 
-export default factories.createCoreRouter('api::site-settings.site-settings');
+export default factories.createCoreRouter<'api::site-settings.site-settings'>(
+  'api::site-settings.site-settings' satisfies UID.ContentType
+);

--- a/apps/cms/src/api/site-settings/services/site-settings.ts
+++ b/apps/cms/src/api/site-settings/services/site-settings.ts
@@ -2,6 +2,12 @@
  * site-settings service
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from '@strapi/strapi';
+import type { UID } from '@strapi/strapi';
 
-export default factories.createCoreService('api::site-settings.site-settings');
+export default factories.createCoreService<
+  'api::site-settings.site-settings',
+  {}
+>(
+  'api::site-settings.site-settings' satisfies UID.ContentType
+);


### PR DESCRIPTION
## Summary
- add type-safe site settings controller
- add typed router and service

## Testing
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npx tsc -p apps/cms/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b42b99344083269899fdcfb3d892dc