### PR TITLE
chore(cms): guard dev bootstrap

### DIFF
--- a/apps/cms/src/index.ts
+++ b/apps/cms/src/index.ts
@@ -17,6 +17,14 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
+    const shouldBootstrap =
+      process.env.NODE_ENV !== 'production' ||
+      process.env.ENABLE_DEV_BOOTSTRAP === 'true';
+
+    if (!shouldBootstrap) {
+      return;
+    }
+
     // 1) Loosen public permissions for read-only content in dev
     try {
       const roleService = (strapi as any).plugins['users-permissions'].services.role


### PR DESCRIPTION
## Summary
- protect dev bootstrap logic from running in production unless explicitly enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64dc11f74832694609395106da9d8