### PR TITLE
Use HTTPS for Strapi and clarify HTTP usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example environment variables for Strapi
-STRAPI_API_URL=http://localhost:1337
+# Use HTTPS for secure communication; plain HTTP is intended only for legacy or local development scenarios
+STRAPI_API_URL=https://localhost:1337
 # Generate a token in Strapi and place it here
 STRAPI_API_TOKEN=
 REVALIDATE_INTERVAL=60 # Next.js fetch revalidation in seconds

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to view th
 Create an `.env.local` file in the project root with the following variables:
 
 ```bash
-STRAPI_API_URL=http://localhost:1337
+STRAPI_API_URL=https://localhost:1337
 STRAPI_API_TOKEN=<your-private-token>
 REVALIDATE_INTERVAL=60 # revalidate Strapi fetches every 60 seconds
+```
+
+Plain HTTP (`http://`) should be used only for legacy or strictly local development scenarios.
 
 The token should be kept server-side for security. Avoid using the
 `NEXT_PUBLIC_` prefix so it is not exposed to the browser.


### PR DESCRIPTION
## Summary
- default STRAPI_API_URL to https in example env file
- document that plain HTTP is only for legacy or local scenarios

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b64deff1a0832680bc1bf08d0c6fa5